### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Get git-semver tool
-        uses: supplypike/setup-bin@v1
+        uses: supplypike/setup-bin@v3
         with:
           uri: https://github.com/mdomke/git-semver/releases/download/v6.3.1/git-semver_6.3.1_Linux_x86_64.tar.gz
           name: git-semver

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,14 +44,14 @@ jobs:
           echo "tag=$(git-semver)" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build container image and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Generate version tag
         id: semver_tag
         run: |
-          echo "::set-output name=tag::$(git-semver)"
+          echo "tag=$(git-semver)" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://bitbucket.org/terndatateam/flask_tern.git@0.8.1
+git+https://bitbucket.org/terndatateam/flask_tern.git@0.8.2


### PR DESCRIPTION
Update all actions to the latest version to avoid using deprecated functions.

Use new `set-output` syntax. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/