### PR TITLE
Remove the usage of docker buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,6 @@ jobs:
       - name: Build project
         run: python setup.py bdist_wheel
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up and use Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Get git-semver tool
         uses: supplypike/setup-bin@v3
         with:


### PR DESCRIPTION
Docker Buildx is only required when creating multi-arch container images. Since we're not doing that here, it's better to not use it.

If we do use it, we have to set `provenance = false` in the `docker/build-push-action` step due to an issue with the image metadata when pushed to GitHub Container Registry. See https://github.com/docker/build-push-action/issues/778 for context. This issue was introduced in [v3.3.0](https://github.com/docker/build-push-action/releases/tag/v3.3.0) of `docker/build-push-action`.